### PR TITLE
rt_linux: Fix arguments to cfg80211_scan_done() for linux-4.8

### DIFF
--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -3220,9 +3220,13 @@ VOID CFG80211OS_ScanEnd(
 #ifdef CONFIG_STA_SUPPORT
 	CFG80211_CB *pCfg80211_CB = (CFG80211_CB *)pCB;
 
+	struct cfg80211_scan_info scan_info = {
+		.aborted = FlgIsAborted
+	};
+
 
 	CFG80211DBG(RT_DEBUG_ERROR, ("80211> cfg80211_scan_done\n"));
-	cfg80211_scan_done(pCfg80211_CB->pCfg80211_ScanReq, FlgIsAborted);
+	cfg80211_scan_done(pCfg80211_CB->pCfg80211_ScanReq, &scan_info);
 #endif /* CONFIG_STA_SUPPORT */
 #endif /* LINUX_VERSION_CODE */
 }


### PR DESCRIPTION
Linux 4.8 changed the parameters to cfg80211_scan_done() in the
respective commit:

* 1d76250 nl80211: support beacon report scanning

Adjust the code accordingly.